### PR TITLE
Add locale.po files (for OJS 3.2+)

### DIFF
--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -1,0 +1,55 @@
+# plugins/generic/formHoneypot/locale/en_US/locale.po
+#
+# Copyright (c) University of Pittsburgh
+# Distributed under the GNU GPL v2 or later. For full terms see the LICENSE file.
+#
+# Form Honeypot plugin localization strings
+
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "plugins.generic.formHoneypot.displayName"
+msgstr "Form Honeypot Plugin"
+
+msgid "plugins.generic.formHoneypot.description"
+msgstr "This plugin will add a field on the user registration form and use it as a honeypot. This field will be hidden "
+"from users and an error will be presented if a bot fills out the field.  You may also select a minimum and maximum "
+"time to allow for form completion.  For example, if a bot completes the form in under 2 seconds or tries to use the "
+"same form 30 minutes (1800 seconds) later, the registration can be blocked."
+
+msgid "plugins.generic.formHoneypot.leaveBlank"
+msgstr "Leave this blank"
+
+msgid "plugins.generic.formHoneypot.doNotUseThisField"
+msgstr "This field must be left blank: {$element}"
+
+msgid "plugins.generic.formHoneypot.invalidSessionTime"
+msgstr "Your registration has been blocked."
+
+msgid "plugins.generic.formHoneypot.manager.formHoneypotSettings"
+msgstr "Form Honeypot Settings"
+
+msgid "plugins.generic.formHoneypot.manager.settings.description"
+msgstr "Choose a minimum time and a maximum time, in seconds. Registration attempts that are completed faster than the "
+"minimum time or slower than the maximum time are rejected. You may disable this feature by setting both limits to 0."
+
+msgid "plugins.generic.formHoneypot.manager.settings.element"
+msgstr "Form Element"
+
+msgid "plugins.generic.formHoneypot.manager.settings.createNewElement"
+msgstr "Create a new element"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTime"
+msgstr "Minimum time (in seconds)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTimeNumber"
+msgstr "Minimum time must be a positive numeric value."
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTime"
+msgstr "Maximum time (in seconds)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTimeNumber"
+msgstr "Maximum time must be a positive numeric value."

--- a/locale/es_ES/locale.po
+++ b/locale/es_ES/locale.po
@@ -1,0 +1,60 @@
+# plugins/generic/formHoneypot/locale/es_ES/locale.po
+#
+# Copyright (c) University of Pittsburgh
+# Distributed under the GNU GPL v2 or later. For full terms see the LICENSE file.
+# 
+# Translation credits: https://pkp.sfu.ca/wiki/index.php?title=OMP:_Spanish_(es_ES)
+#
+# Form Honeypot plugin localization strings
+
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "plugins.generic.formHoneypot.displayName"
+msgstr "Módulo de formulario Honeypot"
+
+msgid "plugins.generic.formHoneypot.description"
+msgstr "Este módulo convierte uno de los campos del formulario de registro de usuario en un honeypot. "
+"El campo escogido se esconderá a los usuarios normales, de manera que, cuando un robot lo complete, se mostrará un "
+"error. Puede configurar el tiempo mínimo y máximo para completar el formulario. Por ejemplo, si un robot completa el "
+"forumlario en 2 segundos o intenta utilizar el mismo formulario 30 minutos (1800 segundos) más tarde, el registro "
+"puede bloquearse."
+
+msgid "plugins.generic.formHoneypot.leaveBlank"
+msgstr "Dejar en blanco"
+
+msgid "plugins.generic.formHoneypot.doNotUseThisField"
+msgstr "Este campo debe dejarse en blanco: {$element}"
+
+msgid "plugins.generic.formHoneypot.invalidSessionTime"
+msgstr "Petición de registro bloqueada."
+	
+msgid "plugins.generic.formHoneypot.manager.formHoneypotSettings"
+msgstr "Configuración del formulario Honeypot"
+
+msgid "plugins.generic.formHoneypot.manager.settings.description"
+msgstr "Escoge el campo del formulario de registro de usuario que quieres convertir en un Honeypot para robots. Este "
+"campo se esconderá a los usuarios normales (mediante javascript), pero los bots lo seguirán viendo e intentarán "
+"completarlo. Si se completase, generaría un error de registro. El campo seguirá estando disponible en el perfil para "
+"los usuarios una vez registrados."
+
+msgid "plugins.generic.formHoneypot.manager.settings.element"
+msgstr "Elemento de formulario"
+
+msgid "plugins.generic.formHoneypot.manager.settings.createNewElement"
+msgstr "Crear un nuevo elemento"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTime"
+msgstr "Tiempo mínimo (en segundos)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTimeNumber"
+msgstr "El tiempo mínimo, debe ser un número positivo."
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTime"
+msgstr "Tiempo máximo (en segundos)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTimeNumber"
+msgstr "El tiempo máximo debe ser un número positivo."

--- a/locale/it_IT/locale.po
+++ b/locale/it_IT/locale.po
@@ -1,0 +1,56 @@
+# plugins/generic/formHoneypot/locale/en_US/locale.po
+#
+# Copyright (c) University of Pittsburgh
+# Distributed under the GNU GPL v2 or later. For full terms see the LICENSE file.
+#
+# Form Honeypot plugin localization strings
+
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "plugins.generic.formHoneypot.displayName"
+msgstr "Plugin Modulo Honeypot"
+
+msgid "plugins.generic.formHoneypot.description"
+msgstr "Questo plugin aggiunge un campo nel modulo di registrazione dei nuovi utenti e lo usa come honeypot. Questo "
+"campo viene nascosto agli utenti e viene presentato un errore se un bot lo compila. Puoi anche selezionare un tempo "
+"minimo e massimo per la compilazione del modulo. Ad esempio, se un bot compila il modulo in meno di 2 secondi o prova "
+"a usare il modulo 30 minuti (1800 secondi) dopo, la registrazione può essere bloccata."
+
+msgid "plugins.generic.formHoneypot.leaveBlank"
+msgstr "Lasciare vuoto"
+
+msgid "plugins.generic.formHoneypot.doNotUseThisField"
+msgstr "Questo campo deve essere lasciato vuoto: {$element}"
+
+msgid "plugins.generic.formHoneypot.invalidSessionTime"
+msgstr "La tua registrazione è stata bloccata."
+
+msgid "plugins.generic.formHoneypot.manager.formHoneypotSettings"
+msgstr "Impostazioni Modulo Honeypot"
+
+msgid "plugins.generic.formHoneypot.manager.settings.description"
+msgstr ""
+"Scegli un tempo minimo e uno massimo, in secondi. Tentativi di reistrazione che vengono completati in meno del tempo "
+"minimo o più del tempo massimo vengono rigettati. Puoi disabilitare questa funzione indicando 0 per entrambi i limiti."
+
+msgid "plugins.generic.formHoneypot.manager.settings.element"
+msgstr "Elemento del modulo"
+
+msgid "plugins.generic.formHoneypot.manager.settings.createNewElement"
+msgstr "Crea un nuovo elemento"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTime"
+msgstr "Tempo minimo (in secondi)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTimeNumber"
+msgstr "Tempo minimo deve essere un valore numerico positivo."
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTime"
+msgstr "Tempo massimo (in secondi)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTimeNumber"
+msgstr "Tempo massimo deve essere un valore numerico positivo."

--- a/locale/nb_NO/locale.po
+++ b/locale/nb_NO/locale.po
@@ -1,0 +1,56 @@
+# locale/nb_NO/locale.po
+#
+# Copyright (c) 2014-2019 Simon Fraser University
+# Copyright (c) 2003-2019 John Willinsky
+# Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+#
+# Localization strings.
+
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "plugins.generic.formHoneypot.displayName"
+msgstr "Form Honeypot Plugin"
+
+msgid "plugins.generic.formHoneypot.description"
+msgstr "Dette programtillegget vil legge til et felt på brukerregistreringsskjemaet og bruke det som en honeypot. "
+"Dette feltet blir skjult for brukere, og en feil vil bli presentert hvis en bot fyller ut feltet. Du kan også velge "
+"en minimums- og maksimaltid for utfylling av skjema. Hvis for eksempel en bot fyller ut skjemaet på under 2 sekunder "
+"eller prøver å bruke samme skjema 30 minutter (1800 sekunder) senere, kan registreringen blokkeres."
+
+msgid "plugins.generic.formHoneypot.leaveBlank"
+msgstr "La dette stå tomt"
+
+msgid "plugins.generic.formHoneypot.doNotUseThisField"
+msgstr "Dette feltet må stå tomt: {$element}"
+
+msgid "plugins.generic.formHoneypot.invalidSessionTime"
+msgstr "Din registrering har blitt blokkert."
+
+msgid "plugins.generic.formHoneypot.manager.formHoneypotSettings"
+msgstr "Form Honeypot innstillinger"
+
+msgid "plugins.generic.formHoneypot.manager.settings.description"
+msgstr "Velg en minimumstid og en maksimal tid, i sekunder. Registreringsforsøk som gjennomføres raskere enn minstetid "
+"eller saktere enn maksimal tid, blir avvist. Du kan deaktivere denne funksjonen ved å sette begge grensene til 0."
+
+msgid "plugins.generic.formHoneypot.manager.settings.element"
+msgstr "Skjemaelement"
+
+msgid "plugins.generic.formHoneypot.manager.settings.createNewElement"
+msgstr "Lag et nytt element"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTime"
+msgstr "Minimumstid (i sekunder)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTimeNumber"
+msgstr "Minimumstid må være en positiv numerisk verdi."
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTime"
+msgstr "Maksimumstid (i sekunder)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTimeNumber"
+msgstr "Maksimumstid må være en positiv numerisk verdi."

--- a/locale/nl_NL/locale.po
+++ b/locale/nl_NL/locale.po
@@ -1,0 +1,57 @@
+# plugins/generic/formHoneypot/locale/en_US/locale.po
+#
+# Copyright (c) University of Pittsburgh
+# Distributed under the GNU GPL v2 or later. For full terms see the LICENSE file.
+#
+# Form Honeypot plugin localization strings
+
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "plugins.generic.formHoneypot.displayName"
+msgstr "Formulier Honeypot Plugin"
+
+msgid "plugins.generic.formHoneypot.description"
+msgstr "Deze plugin voegt een verborgen veld toe aan het registratieformulier, dat gebruikt wordt als \"lokveld\". "
+"Dit veld wordt niet getoond op de website en mag niet worden ingevuld. Wanneer een bot het veld invult, wordt een "
+"foutmelding getoond. U kunt ook een minimum en maximum tijd instellen voor het invullen van het registratieformulier. "
+"Bijvoorbeeld, wanneer een bot het formulier in minder dan 2 seconden invult, of hetzelfde formulier 30 minuten "
+"(1800 seconden) later wil gebruiken, kan de registratie worden geblokkeerd."
+
+msgid "plugins.generic.formHoneypot.leaveBlank"
+msgstr "Laat leeg"
+
+msgid "plugins.generic.formHoneypot.doNotUseThisField"
+msgstr "Dit veld moet leeg blijven: {$element}"
+
+msgid "plugins.generic.formHoneypot.invalidSessionTime"
+msgstr "Uw registratiepoging is geblokkeerd."
+
+msgid "plugins.generic.formHoneypot.manager.formHoneypotSettings"
+msgstr "Formulier Honeypot instellingen"
+
+msgid "plugins.generic.formHoneypot.manager.settings.description"
+msgstr "Kies een minimum en maximum tijd, in seconden. Registratiepogingen die sneller dan de minimumtijd worden "
+"voltooid, of trager dan de maximumtijd, worden geblokkeerd. U kunt deze instellingen uitschakelen door 0 in te "
+"vullen als waarde."
+
+msgid "plugins.generic.formHoneypot.manager.settings.element"
+msgstr "Formulier-element"
+
+msgid "plugins.generic.formHoneypot.manager.settings.createNewElement"
+msgstr "Creëer een nieuw element"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTime"
+msgstr "Minimumtijd (in seconden)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTimeNumber"
+msgstr "Minimumtijd moet een postitief getal zijn."
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTime"
+msgstr "Maximumtijd (in seconden)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTimeNumber"
+msgstr "Maximumtijd moet een postitief getal zijn."

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -1,0 +1,58 @@
+# plugins/generic/formHoneypot/locale/pt_BR/locale.po
+#
+# Copyright (c) University of Pittsburgh
+# Distributed under the GNU GPL v2 or later. For full terms see the LICENSE file.
+#
+# Form Honeypot plugin localization strings
+
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "plugins.generic.formHoneypot.displayName"
+msgstr "Plugin Formulário Pote de Mel (Honeypot)"
+
+msgid "plugins.generic.formHoneypot.description"
+msgstr "Este plugin irá converter um dos campos no formulário de cadastro do usuário em um pote de mel (honeypot). "
+"Este campo estará escondido dos usuários e um erro será apresentado se um bot preencher o campo. Você também pode "
+"selecionar um tempo mínimo e máximo para permitir a conclusão do formulário. Por exemplo, se um bot concluir o "
+"formulário em menos de 2 segundos ou tentar usar o mesmo formulário 30 minutos (1800 segundos) depois, o cadastro "
+"poderá ser bloqueado."
+
+msgid "plugins.generic.formHoneypot.leaveBlank"
+msgstr "Deixar isso em branco"
+
+msgid "plugins.generic.formHoneypot.doNotUseThisField"
+msgstr "Este campo deve estar em branco: {$element}"
+
+msgid "plugins.generic.formHoneypot.invalidSessionTime"
+msgstr "Seu cadastro foi bloqueado."
+
+msgid "plugins.generic.formHoneypot.manager.formHoneypotSettings"
+msgstr "Configurações do Formulário Honeypot"
+
+msgid "plugins.generic.formHoneypot.manager.settings.description"
+msgstr "Selecione o campo no formulário de cadastro que você gostaria de converter em um pote de mel (honeypot) de bot. "
+"Este campo estará escondido de usuários normais via javascript, mas os bots provavelmente ainda o verão e tentarão "
+"usar o campo. Usar este campo resultará em um erro de registro. O campo ainda estará disponível para os usuários do "
+"formulário de perfil do usuário após o cadastro."
+
+msgid "plugins.generic.formHoneypot.manager.settings.element"
+msgstr "Elemento do formulário"
+
+msgid "plugins.generic.formHoneypot.manager.settings.createNewElement"
+msgstr "Criar novo elemento"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTime"
+msgstr "Tempo mínimo (em segundos)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTimeNumber"
+msgstr "Tempo mínimo deve ser um valor numérico positivo."
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTime"
+msgstr "Tempo máximo (em segundos)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTimeNumber"
+msgstr "Tempo máximo deve ser um valor numérico positivo."

--- a/locale/sv_SE/locale.po
+++ b/locale/sv_SE/locale.po
@@ -1,0 +1,56 @@
+# locale/sv_SE/locale.xml
+#
+# Copyright (c) University of Pittsburgh
+# Distributed under the GNU GPL v2 or later. For full terms see the file docs/COPYING.
+#
+# Localization strings.
+
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "plugins.generic.formHoneypot.displayName"
+msgstr "Form Honeypot Plugin"
+
+msgid "plugins.generic.formHoneypot.description"
+msgstr ""
+"Denna insticksmodul lägger till ett fält i användarregistreringsformuläret och använder det som en honungsfälla. "
+"Fältet är dolt för användare och ett fel visas om det fylls i av en bot. Du kan också välja en minimum- och maximumtid "
+"för ifyllning av formuläret. Om till exempel en bot fyller i formuläret på två sekunder och försöker använda samma "
+"formulär 30 minuter (1800 sekunder) senare, kan registreringen blockeras."
+
+msgid "plugins.generic.formHoneypot.leaveBlank"
+msgstr "Lämna detta fält tomt"
+
+msgid "plugins.generic.formHoneypot.doNotUseThisField"
+msgstr "Det här fältet måste vara tomt: {$element}"
+
+msgid "plugins.generic.formHoneypot.invalidSessionTime"
+msgstr "Din registrering har blivit blockerad."
+
+msgid "plugins.generic.formHoneypot.manager.formHoneypotSettings"
+msgstr "Form Honeypot inställningar"
+
+msgid "plugins.generic.formHoneypot.manager.settings.description"
+msgstr "Välj en minimumtid och en maximumtid, i sekunder. Registreringsförsök som görs snabbare än minimumtiden eller "
+"långsammare än maximumtiden blir avvisade. Du kan avvaktivera denna funktion genom att sätta bägge gränserna till 0."
+
+msgid "plugins.generic.formHoneypot.manager.settings.element"
+msgstr "Formulärfält"
+
+msgid "plugins.generic.formHoneypot.manager.settings.createNewElement"
+msgstr "Skapa ett nytt fält"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTime"
+msgstr "Minimumtid (i sekunder)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.minimumTimeNumber"
+msgstr "Minimumtid måste vara ett positivt tal"
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTime"
+msgstr "Maximumtid (i sekunder)"
+
+msgid "plugins.generic.formHoneypot.manager.settings.maximumTimeNumber"
+msgstr "Maximumtid måste vara ett positivt tal."


### PR DESCRIPTION
The file format for translations changed in OJS 3.2 [1].
This adds locale files with the same content in the new format for
existing translations.

[1] https://docs.pkp.sfu.ca/translating-guide/en/translate-software